### PR TITLE
feat(dropdown): remove label shadow

### DIFF
--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -208,6 +208,34 @@
               <div class="item" data-value="bananas">Bananas</div>
             </div>
           </div>
+          <br>
+          <br>
+          <div class="ui multiple selection dropdown">
+            <a class="ui label">Postal Code <i class="delete icon"></i></a>
+            <a class="ui label">First Name <i class="delete icon"></i></a>
+            <i class="dropdown icon"></i>
+          </div>
+          <br>
+          <br>
+          <div class="ui multiple selection dropdown">
+            <a class="ui basic label">Postal Code <i class="delete icon"></i></a>
+            <a class="ui basic label">First Name <i class="delete icon"></i></a>
+            <i class="dropdown icon"></i>
+          </div>
+          <br>
+          <br>
+          <div class="ui multiple selection dropdown">
+            <a class="ui blue label">Postal Code <i class="delete icon"></i></a>
+            <a class="ui blue label">First Name <i class="delete icon"></i></a>
+            <i class="dropdown icon"></i>
+          </div>
+          <br>
+          <br>
+          <div class="ui multiple selection dropdown">
+            <a class="ui basic blue label">Postal Code <i class="delete icon"></i></a>
+            <a class="ui basic blue label">First Name <i class="delete icon"></i></a>
+            <i class="dropdown icon"></i>
+          </div>
         </div>
       </div>
       <div class="ui segment">

--- a/src/site/modules/dropdown.variables
+++ b/src/site/modules/dropdown.variables
@@ -1,3 +1,4 @@
 /*******************************
     User Variable Overrides
 *******************************/
+@labelBoxShadow: none;


### PR DESCRIPTION
This PR removes the box-shadow from labels in a dropdown.  The box shadow was being used as a a pseudo border, which then doubled up with the `basic label` border making two borders.  Worse, one was removed on hover making a jarring interaction.

![image](https://cloud.githubusercontent.com/assets/5067638/20936280/e6f4b4ee-bb96-11e6-9a7f-9511e2c3531c.png)

The border-free labels are also more in line with the `action input` button:

![image](https://cloud.githubusercontent.com/assets/5067638/20936338/1c0100ac-bb97-11e6-8727-bc757563cc5e.png)
