### PR TITLE
chore(package): deploy to cdn.taplatform.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Semantic UI theme for internal TechnolgoyAdvice apps.
 
 **NPM**
 
-```bash
+```
 npm i @technologyadvice/radiant -S
 ```
 
 **CDN**
 
-```bash
-d6xw8h2ajn62r.cloudfront.net/x.x.x/css/radiant.min.css
+```
+cdn.taplatform.net/radiant/x.x.x/css/radiant.min.css
 ```
 
 ## Usage

--- a/circle.yml
+++ b/circle.yml
@@ -26,4 +26,5 @@ deployment:
 
       # s3 sync
       - echo "...syncing with s3"
-      - ta-script aws/s3_sync -d ./dist -b ta-radiant-assets/$(json -f package.json version)
+      - npm run build
+      - ta-script aws/s3_sync -d ./dist -b cdn.taplatform.net/radiant/$(json -f package.json version)


### PR DESCRIPTION
This PR moves `radiant` to our primary `cdn.taplatform.net` delivery system.  The old CDN will be left in place for now.  We'll remove it when we're sure it is no longer in use.