### PR TITLE
feat(checkbox): restore blue toggle color

### DIFF
--- a/src/site/modules/checkbox.variables
+++ b/src/site/modules/checkbox.variables
@@ -1,5 +1,3 @@
 /*******************************
     User Variable Overrides
 *******************************/
-@toggleOnLaneColor: @green;
-@toggleOnFocusLaneColor: @greenFocus;


### PR DESCRIPTION
We used to need green toggle's for the calling interface.  Those days are gone.  This PR restores the original checkbox color.
***

# Before
![image](https://cloud.githubusercontent.com/assets/5067638/22807340/43f9df26-eedb-11e6-8a34-a3e14334338d.png)

# After
![image](https://cloud.githubusercontent.com/assets/5067638/22807353/5088a68c-eedb-11e6-85c9-add9bf9ce57e.png)
